### PR TITLE
Use the error_message returned as the RequestDeniedError message

### DIFF
--- a/lib/google_places/error.rb
+++ b/lib/google_places/error.rb
@@ -5,9 +5,13 @@ module GooglePlaces
   # Thrown when a request was denied by the server
   #
   # This can be the case when:
+  # - API key is not authorized for the Places API
   # - querying the SPOT_LIST_URL <b>without</b> the following parameters:
   # - - key
   class RequestDeniedError < HTTParty::ResponseError
+    def to_s
+      response.parsed_response['error_message']
+    end
   end
 
   # Thrown when a request was rejected as invalid by the server


### PR DESCRIPTION
Google provides useful error messages when the request is denied, so it's nice to include that in the error. If an error gets raised, the message will be included in your error monitoring service, making it easy to know why it failed and go about fixing it.

I opted to stub the denied request explicitly rather than having to use a separate API key without the proper permissions to simulate the error.